### PR TITLE
Pass height parameter to camera config

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ func main() {
 	// Set parameters
 	cfg.Format = mjpeg.FourCC
 	cfg.Width = arguments.Width
-	cfg.Width = arguments.Width
+	cfg.Height = arguments.Height
 
 	// Apply config
 	err = cam.SetConfig(cfg)


### PR DESCRIPTION
`README` command will fail to setup camera height parameters on this line, and it's keeping the default camera height config (768px in our case)