### PR TITLE
Features: add mllib parameters for service creation, --keep options also keeps json responses

### DIFF
--- a/arguments.go
+++ b/arguments.go
@@ -75,6 +75,9 @@ var arguments = struct {
 	Mllib              string
 	Connector          string
 	Init               string
+  MlLibDataType           string
+  MlLibMaxBatchSize       int
+	MlLibMaxWorkspaceSize   int
 	// Mask
 	Mask       bool
 	Contour    bool
@@ -274,6 +277,21 @@ func argumentsParsing(args []string) {
 		Help:     "If the GPU should be used or not",
 		Default:  false})
 
+	MlLibDataType := parser.String("", "mllib-datatype", &argparse.Options{
+		Required: false,
+		Help:     "Mllib data type during service creation (fp32, fp16)",
+		Default:  ""})
+
+	MlLibMaxBatchSize := parser.Int("", "mllib-max-batch-size", &argparse.Options{
+		Required: false,
+		Help:     "Mllib max batch size",
+		Default:  -1})
+
+	MlLibMaxWorkspaceSize := parser.Int("", "mllib-max-workspace-size", &argparse.Options{
+		Required: false,
+		Help:     "Mllib max workspace size, in Mo",
+		Default:  -1})
+
 	// Classes
 	selectClasses := parser.Flag("", "select-classes", &argparse.Options{
 		Required: false,
@@ -349,6 +367,9 @@ func argumentsParsing(args []string) {
 	arguments.Mllib = *mllib
 	arguments.Connector = *connector
 	arguments.GPU = *GPU
+	arguments.MlLibDataType = *MlLibDataType
+	arguments.MlLibMaxBatchSize = *MlLibMaxBatchSize
+	arguments.MlLibMaxWorkspaceSize = *MlLibMaxWorkspaceSize
 	arguments.Video = videoPath
 	arguments.SelectClasses = *selectClasses
 	arguments.Classes = classes

--- a/createService.go
+++ b/createService.go
@@ -49,6 +49,18 @@ func createService(URL string) {
 	service.Parameters.Mllib.Nclasses = arguments.Nclasses
 	service.Parameters.Mllib.GPU = arguments.GPU
 
+  if len(arguments.MlLibDataType) > 0 {
+    service.Parameters.Mllib.Datatype = arguments.MlLibDataType
+  }
+
+  if arguments.MlLibMaxBatchSize != -1 {
+    service.Parameters.Mllib.MaxBatchSize = arguments.MlLibMaxBatchSize
+  }
+
+  if arguments.MlLibMaxWorkspaceSize  != -1 {
+    service.Parameters.Mllib.MaxWorkspaceSize = arguments.MlLibMaxWorkspaceSize
+  }
+
 	if service.Model.Init != "" {
 	   service.Model.CreateRepository = true
 	}

--- a/createService.go
+++ b/createService.go
@@ -51,7 +51,7 @@ func createService(URL string) {
 
 	if service.Model.Init != "" {
 	   service.Model.CreateRepository = true
-	}	
+	}
 
 	// Mask support
 	if arguments.Mask == true {

--- a/deepdetect.go
+++ b/deepdetect.go
@@ -28,7 +28,8 @@ package main
 
 import (
 	"image"
-	"time"
+  "time"
+  "strings"
 )
 
 func deepdetectProcess(imagePath string, ID string, img image.Image, startTime time.Time, imageBase64 string) {
@@ -53,4 +54,10 @@ func deepdetectProcess(imagePath string, ID string, img image.Image, startTime t
 	if responsePredict.Status.Code == 200 {
 		printResponse(responsePredict, ID, img, imagePath, startTime)
 	}
+
+  if arguments.Keep == true {
+    var logPath string
+    logPath = strings.TrimSuffix(imagePath, ".jpg") + ".json"
+    go keepJson(logPath, responsePredict)
+  }
 }

--- a/utils.go
+++ b/utils.go
@@ -27,12 +27,17 @@
 package main
 
 import (
+  "bufio"
 	"image"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 
+  "encoding/json"
+  "io/ioutil"
+
+	"github.com/jolibrain/godd"
 	jpeg "github.com/pixiv/go-libjpeg/jpeg"
 )
 
@@ -41,8 +46,18 @@ func keep(filePath string, img *image.RGBA) {
 	if err != nil {
 		panic(err.Error())
 	}
-	defer f.Close()
-	jpeg.Encode(f, img, &jpeg.EncoderOptions{})
+  w := bufio.NewWriter(f)
+  if err := jpeg.Encode(w, img, &jpeg.EncoderOptions{}); err != nil {
+    logError("Jpeg encode returns error: " + err.Error(), "[ERROR]")
+    return
+  }
+  w.Flush()
+  f.Close()
+}
+
+func keepJson(filePath string, result godd.PredictResult) {
+  file, _ := json.Marshal(result)
+  _ = ioutil.WriteFile(filePath, file, 0644)
 }
 
 func floatToString(inputNum float64) string {


### PR DESCRIPTION
- new parameters for mllib available through command line argements:
  - `--mllib-datatype`: Mllib data type (string, fp32, fp16), default null
  - `--mllib-batch-size`: Mllib bat size (int), default null
  - `--mllib-workspace-size`: Mllib workspace size in Mo (int), default null
- compatible with latest commit on `github.com/jolibrain/godd` go lib: https://github.com/jolibrain/godd/commit/ae5a168df98f1ca38df44f74866ec6fdc349546f
- update your go lib with this command: `go get -u github.com/jolibrain/godd`
- `--keep` argument also keeps deepdetect server response next to the image file