### PR TITLE
Feature: --waiting flag to wait seconds between predict requests

### DIFF
--- a/arguments.go
+++ b/arguments.go
@@ -65,6 +65,7 @@ var arguments = struct {
 	Detection  bool
 	Confidence float64
 	SSL        bool
+	Waiting	   int
 	// Creation flags
 	Create             bool
 	GPU                bool
@@ -75,8 +76,8 @@ var arguments = struct {
 	Mllib              string
 	Connector          string
 	Init               string
-  MlLibDataType           string
-  MlLibMaxBatchSize       int
+	MlLibDataType           string
+	MlLibMaxBatchSize       int
 	MlLibMaxWorkspaceSize   int
 	// Mask
 	Mask       bool
@@ -90,7 +91,8 @@ var arguments = struct {
 	Confidence: 0.10,
 	FPS:        30.00,
 	DeviceID:   0,
-	Best:       3}
+	Best:       3,
+	Waiting:    0}
 
 func argumentsParsing(args []string) {
 	// Create new parser object
@@ -235,6 +237,11 @@ func argumentsParsing(args []string) {
 		Required: false,
 		Help:     "Use HTTPS instead of HTTP",
 		Default:  false})
+	
+	waiting := parser.Int("", "waiting", &argparse.Options{
+		Required: false,
+		Help:     "Waiting X seconds between predict requests",
+		Default:  0})
 
 	// Services creation flags
 	create := parser.Flag("", "create", &argparse.Options{
@@ -359,6 +366,7 @@ func argumentsParsing(args []string) {
 	arguments.Verbose = *verbose
 	arguments.DeviceID = *deviceID
 	arguments.SSL = *SSL
+	arguments.Waiting = *waiting
 	arguments.Create = *create
 	arguments.Nclasses = *nclasses
 	arguments.Template = *template

--- a/process.go
+++ b/process.go
@@ -137,12 +137,22 @@ func process(cam *v4l.Device) {
 		if err != nil {
 			logError("Unable to get terminal dimensions!", "[ERROR]")
 		}
+		
+		// Show log message about waiting period
+		if arguments.Waiting > 0 {
+			logSuccess("Waiting " + arguments.Waiting " seconds before next request", "[INFO]")
+		}
 
 		// Pretty horizontal bar displaying
 		if arguments.Verbose == "INFO" || arguments.Verbose == "DEBUG" {
 			for j := 0; j < width; j++ {
 				fmt.Print(color.Green("="))
 			}
+		}
+		
+		// Wait `arguments.Waiting` seconds before next request
+		if arguments.Waiting > 0 {
+			time.Sleep(arguments.Waiting * time.Second)
 		}
 	}
 }

--- a/process.go
+++ b/process.go
@@ -140,7 +140,7 @@ func process(cam *v4l.Device) {
 		
 		// Show log message about waiting period
 		if arguments.Waiting > 0 {
-			logSuccess("Waiting " + arguments.Waiting " seconds before next request", "[INFO]")
+			logSuccess("Waiting " + strconv.Itoa(arguments.Waiting) + " seconds before next request", "[INFO]")
 		}
 
 		// Pretty horizontal bar displaying
@@ -152,7 +152,7 @@ func process(cam *v4l.Device) {
 		
 		// Wait `arguments.Waiting` seconds before next request
 		if arguments.Waiting > 0 {
-			time.Sleep(arguments.Waiting * time.Second)
+			time.Sleep(time.Duration(arguments.Waiting) * time.Second)
 		}
 	}
 }


### PR DESCRIPTION
New `--waiting` argument that allows process to wait for X seconds between each request.

Current, and default, value is 0, there's no waiting time.