### PR TITLE
Fix: remove `CREATE DATABASE` influx query

### DIFF
--- a/influx.go
+++ b/influx.go
@@ -122,16 +122,6 @@ func initDB() {
 	logSuccess("Connected to "+color.Cyan("InfluxDB")+
 		color.Yellow(" instance."), "[INFO]")
 
-	// Initialize database if it doesn't already exist
-	// _, err = queryDB(arguments.InfluxDB, client, fmt.Sprintf("CREATE DATABASE %s", arguments.InfluxDB))
-	// if err != nil {
-	//	logError("Error while creating the database "+
-	//		arguments.InfluxDB+": "+err.Error(), "[ERROR]")
-	//	os.Exit(1)
-	// }
-	// logSuccess("Database "+color.Cyan(arguments.InfluxDB)+
-	//	color.Yellow(" ready."), "[INFO]")
-
 	// Pretty horizontal bar displaying
 	for j := 0; j < width; j++ {
 		fmt.Print(color.Green("="))

--- a/influx.go
+++ b/influx.go
@@ -123,14 +123,14 @@ func initDB() {
 		color.Yellow(" instance."), "[INFO]")
 
 	// Initialize database if it doesn't already exist
-	_, err = queryDB(arguments.InfluxDB, client, fmt.Sprintf("CREATE DATABASE %s", arguments.InfluxDB))
-	if err != nil {
-		logError("Error while creating the database "+
-			arguments.InfluxDB+": "+err.Error(), "[ERROR]")
-		os.Exit(1)
-	}
-	logSuccess("Database "+color.Cyan(arguments.InfluxDB)+
-		color.Yellow(" ready."), "[INFO]")
+	// _, err = queryDB(arguments.InfluxDB, client, fmt.Sprintf("CREATE DATABASE %s", arguments.InfluxDB))
+	// if err != nil {
+	//	logError("Error while creating the database "+
+	//		arguments.InfluxDB+": "+err.Error(), "[ERROR]")
+	//	os.Exit(1)
+	// }
+	// logSuccess("Database "+color.Cyan(arguments.InfluxDB)+
+	//	color.Yellow(" ready."), "[INFO]")
 
 	// Pretty horizontal bar displaying
 	for j := 0; j < width; j++ {


### PR DESCRIPTION
Current version of livedetect is closing if the database already exists and the user don't have permission to create one.

Influx database should be created outside livedetect (directly from an influx client), before running livedetect.

If no database with specified name is available, livedetect will just raise a warning.