### PR TITLE
Feature: add `path` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,4 +240,15 @@ To use InfluxDB, you first need to pass the `--influx` argument, then you can sp
 
 - **Running DeepDetect on one machine and LiveDetect on another**: This is a common setup, typically running the DeepDetect container on a powerful GPU machine, and the LiveDetect binary somewhere near the camera, on a small board. Simply use the `--host` and `--port` parameters to fit your setup.
 
+- **Running DeepDetect behind a reverse proxy**: If you use [DeepDetect Platform](https://deepdetect.com/platform/), your DeepDetect server will be accessible behind an nginx reverse proxy. You can use `--path` parameter to access it:
+
+```
+./livedetect \
+  --host localhost \
+  --port 1912 \
+  --path /api/deepdetect \
+  --mllib caffe \
+  --width 300 --height 300 \
+  --detection
+```
 

--- a/arguments.go
+++ b/arguments.go
@@ -58,6 +58,7 @@ var arguments = struct {
 	// Predict flags
 	Host       string
 	Port       string
+	Path       string
 	Width      int
 	Height     int
 	Best       int
@@ -113,6 +114,11 @@ func argumentsParsing(args []string) {
 		Required: false,
 		Help:     "Port used by your DeepDetect instance",
 		Default:  "8080"})
+
+	path := parser.String("", "path", &argparse.Options{
+		Required: false,
+    Help:     "Url Path of your DeepDetect instance (i.e: /api/deepdetect)",
+		Default:  ""})
 
 	init := parser.String("", "init", &argparse.Options{
 		Required: false,
@@ -350,6 +356,7 @@ func argumentsParsing(args []string) {
 	// Finally save the collected flags
 	arguments.Host = *host
 	arguments.Port = *port
+	arguments.Path = *path
 	arguments.Init = *init
 	arguments.Width = *width
 	arguments.Height = *height

--- a/deepdetect.go
+++ b/deepdetect.go
@@ -47,6 +47,10 @@ func deepdetectProcess(imagePath string, ID string, img image.Image, startTime t
 		predictURL = "http://" + arguments.Host + ":" + arguments.Port
 	}
 
+  if arguments.Path != "" {
+    predictURL = predictURL + arguments.Path
+  }
+
 	// Execute predict
 	responsePredict := predict(predictURL, imageBase64, ID)
 


### PR DESCRIPTION
Add `path` parameter to access DeepDetect servers behind nginx proxy