### PR TITLE
feat: --service-config parameter reads json file with predict request parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,3 +252,46 @@ To use InfluxDB, you first need to pass the `--influx` argument, then you can sp
   --detection
 ```
 
+- **Predict request on multiple services at once**: a json config file can be use to run multiple predict request on different services for each captured image. Here is an example, named `serviceConfig.json`:
+
+```
+[
+  {
+    "service": "detection_600",
+    "parameters": {
+      "input": {},
+      "output": {
+        "confidence_threshold": 0.5,
+        "bbox": true
+      },
+      "mllib": {
+        "gpu": true
+      }
+    }
+  },
+  {
+    "service": "detectron_3k",
+    "parameters": {
+      "input": {},
+      "output": {
+        "confidence_threshold": 0.5,
+        "bbox": true
+      },
+      "mllib": {
+        "gpu": true
+      }
+    }
+  }
+]
+```
+
+Then use `livedetect` command with `--service-config` argument:
+
+```
+./livedetect \
+  --host localhost \
+  --port 8080 \
+  --detection \
+  --service-config ./serviceConfig.json \
+  -v INFO
+```

--- a/deepdetect.go
+++ b/deepdetect.go
@@ -30,10 +30,14 @@ import (
 	"image"
   "time"
   "strings"
+
+	"github.com/jolibrain/godd"
 )
 
 func deepdetectProcess(imagePath string, ID string, img image.Image, startTime time.Time, imageBase64 string) {
+
 	var predictURL string
+  var request godd.PredictRequest
 
 	if arguments.Verbose == "INFO" || arguments.Verbose == "DEBUG" {
 		logSuccess("Processing image "+imagePath,
@@ -52,16 +56,62 @@ func deepdetectProcess(imagePath string, ID string, img image.Image, startTime t
   }
 
 	// Execute predict
-	responsePredict := predict(predictURL, imageBase64, ID)
+  if arguments.ServiceConfig == nil {
+
+    // Use only arguments.Service as predict service
+    responsePredict := predict(predictURL, imageBase64, ID)
+
+    // Handle response
+    deepdetectResponseHandler(responsePredict, imagePath, ID, img, startTime, request)
+
+  } else {
+
+    // Iterate through arguments.ServiceConfig predict services
+    for i := 0; i < len(arguments.ServiceConfig); i++ {
+
+      request = arguments.ServiceConfig[i]
+
+      if arguments.Verbose == "INFO" || arguments.Verbose == "DEBUG" {
+        logSuccess("Request on service " + request.Service,
+          "["+ID+"] [INFO]")
+      }
+
+      responsePredict := predictWithRequest(request, predictURL, imageBase64, ID)
+
+      // Handle response
+      deepdetectResponseHandler(responsePredict, imagePath, ID, img, startTime, request)
+
+    }
+  }
+}
+
+func deepdetectResponseHandler(responsePredict godd.PredictResult, imagePath string, ID string, img image.Image, startTime time.Time, request godd.PredictRequest) {
+
+    if arguments.Verbose == "INFO" || arguments.Verbose == "DEBUG" {
+      logSuccess("Handle predict response",
+        "["+ID+"] [INFO]")
+    }
 
 	// Print predict results
 	if responsePredict.Status.Code == 200 {
 		printResponse(responsePredict, ID, img, imagePath, startTime)
 	}
 
+  // Keep json object on disk
   if arguments.Keep == true {
+
+    // Place json file next to processed image file
     var logPath string
     logPath = strings.TrimSuffix(imagePath, ".jpg") + ".json"
+
+    // Add Service name suffix if specified
+    if request.Service != "" {
+      logPath = strings.Replace(logPath, ".json", "_" + request.Service + ".json", -1)
+    }
+
+    // Write predict response inside json file
     go keepJson(logPath, responsePredict)
+
   }
+
 }

--- a/predict.go
+++ b/predict.go
@@ -30,6 +30,20 @@ import (
 	"github.com/jolibrain/godd"
 )
 
+func predictWithRequest(predict godd.PredictRequest, URL string, image string, ID string) godd.PredictResult {
+	predict.Data = append(predict.Data, image)
+
+	predictResult, err := godd.Predict(URL, &predict)
+	if err != nil {
+		logError("Can't execute request!",
+			"["+ID+"] [ERROR]")
+		logError("Reason: "+err.Error(),
+			"["+ID+"] [ERROR]")
+	}
+
+	return predictResult
+}
+
 func predict(URL string, image string, ID string) godd.PredictResult {
 	// Create predict structure
 	var predict godd.PredictRequest


### PR DESCRIPTION
Predict request on multiple services at once: a json config file can be used to run multiple predict requests on different services for each captured image.