### PR TITLE
fix: write multiple bboxes/masks on original image

### DIFF
--- a/responseHandling.go
+++ b/responseHandling.go
@@ -105,11 +105,11 @@ func printResponse(request godd.PredictRequest, result godd.PredictResult, ID st
 							fmt.Print("\n")
 						}
 						if arguments.Preview != "" || arguments.Keep == true {
-							imgRGBA = writeMask(img, result, categories, ID)
+							imgRGBA = writeMask(imgRGBA, result, categories, ID)
 						}
 					} else {
 						if arguments.Preview != "" || arguments.Keep == true {
-							imgRGBA = writeBoundingBox(img, result, categories, ID, index)
+							imgRGBA = writeBoundingBox(imgRGBA, result, categories, ID, index)
 						}
 					}
 				}


### PR DESCRIPTION
Original image was used to write each bounding box.

This caused an issue when there was multiple bounding boxes ans masks